### PR TITLE
Permission patch suggestion

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -33,15 +33,26 @@ class Plugin extends PluginBase
         ];
     }
 
+    public function registerPermissions()
+    {
+        return [
+            'anandpatel.wysiwygeditors.manage_wysiwyg' => [
+                'tab' => 'anandpatel.wysiwygeditors::lang.permissions.name',
+                'label' => 'anandpatel.wysiwygeditors::lang.permissions.manage_wysiwyg'
+            ],
+        ];
+    }
+
     public function registerSettings()
     {
         return [
             'settings' => [
-                'label' => 'anandpatel.wysiwygeditors::lang.settings.label',
+                'label'       => 'anandpatel.wysiwygeditors::lang.settings.label',
                 'description' => 'anandpatel.wysiwygeditors::lang.settings.description',
-                'icon' => 'icon-pencil-square-o',
-                'class' => 'AnandPatel\WysiwygEditors\Models\Settings',
-                'category' => SettingsManager::CATEGORY_CMS
+                'icon'        => 'icon-pencil-square-o',
+                'class'       => 'AnandPatel\WysiwygEditors\Models\Settings',
+                'category'    => SettingsManager::CATEGORY_CMS,
+                'permissions' => ['anandpatel.wysiwygeditors.manage_wysiwyg'],
             ]
         ];
     }

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -9,6 +9,10 @@ return [
         'label' => 'Wysiwyg Editors',
         'description' => 'Configure Wysiwyg Editors preferences.'
     ],
+    'permissions' => [
+        'name' => 'Wysiwyg Editors',
+		'manage_wysiwyg' => 'Can manage Wysiwyg Editors settings'
+    ],
     'widget' => [
         'label' => 'Wysiwyg',
         'name' => 'Wysiwyg Editors',

--- a/lang/pt-br/lang.php
+++ b/lang/pt-br/lang.php
@@ -9,6 +9,10 @@ return [
         'label' => 'Editores Wysiwyg',
         'description' => 'Configura as preferências de Editores Wysiwyg.'
     ],
+    'permissions' => [
+        'name' => 'Editores Wysiwyg',
+		'manage_wysiwyg' => 'Permite configurar as preferências de Editores Wysiwyg'
+    ],
     'widget' => [
         'label' => 'Wysiwyg',
         'name' => 'Editores Wysiwyg',


### PR DESCRIPTION
The plugin is great but having its settings wide open to any backend user is a big headache for us so I've implemented a small enhancement that registers the plugin permission on the backend so that, like in my case, if someone doesn't want some users to be able to toy with the Wysiwyg settings, this can be done on the October permissions menu.
